### PR TITLE
Add the profile's PID to child records of a profile

### DIFF
--- a/Classes/Command/CreateProfilesCommand.php
+++ b/Classes/Command/CreateProfilesCommand.php
@@ -38,27 +38,12 @@ final class CreateProfilesCommand extends Command
 
     protected function configure(): void
     {
-        $this
-            ->setHelp('This command create profiles for all frontend users that do not have a profile yet but should have one.')
-            ->addOption(
-                'storage-pid',
-                's',
-                InputOption::VALUE_REQUIRED,
-                'Storage PID for the fe_user records.',
-                0
-            );
+        $this->setHelp('This command create profiles for all frontend users that do not have a profile yet but should have one.');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $storagePid = (int)$input->getOption('storage-pid');
-
-        if ($storagePid <= 0) {
-            $output->writeln('<error>StoragePid needs to be a positive integer.</error>');
-            return Command::FAILURE;
-        }
-
-        $frontendUsers = $this->frontendUserProvider->getUsersWithoutProfile($storagePid);
+        $frontendUsers = $this->frontendUserProvider->getUsersWithoutProfile();
 
         foreach ($frontendUsers as $frontendUser) {
             $frontendUserAuthentication = GeneralUtility::makeInstance(FrontendUserAuthentication::class);

--- a/Classes/Profile/ProfileFactory.php
+++ b/Classes/Profile/ProfileFactory.php
@@ -24,7 +24,10 @@ final class ProfileFactory extends AbstractProfileFactory
      */
     protected function createProfileFromFrontendUser(array $frontendUserData): Profile
     {
+        $pid = (int)$frontendUserData['pid'];
+
         $profile = new Profile();
+        $profile->setPid($pid);
         $profile->setTitle((string)($frontendUserData['title'] ?? ''));
         $profile->setFirstName((string)($frontendUserData['first_name'] ?? ''));
         $profile->setMiddleName((string)($frontendUserData['middle_name'] ?? ''));
@@ -32,9 +35,11 @@ final class ProfileFactory extends AbstractProfileFactory
         $profile->setWebsite((string)($frontendUserData['www'] ?? ''));
 
         $contract = new Contract();
+        $contract->setPid($pid);
         $profile->getContracts()->attach($contract);
 
         $address = new Address();
+        $address->setPid($pid);
         $address->setStreet((string)($frontendUserData['address'] ?? ''));
         $address->setZip((string)($frontendUserData['zip'] ?? ''));
         $address->setCity((string)($frontendUserData['city'] ?? ''));
@@ -43,18 +48,21 @@ final class ProfileFactory extends AbstractProfileFactory
 
         if (!empty($frontendUserData['email'])) {
             $email = new Email();
+            $email->setPid($pid);
             $email->setEmail((string)($frontendUserData['email']));
             $contract->getEmailAddresses()->attach($email);
         }
 
         if (!empty($frontendUserData['telephone'])) {
             $phoneNumber = new PhoneNumber();
+            $phoneNumber->setPid($pid);
             $phoneNumber->setPhoneNumber((string)($frontendUserData['telephone']));
             $phoneNumber->setType('phone');
             $contract->getPhoneNumbers()->attach($phoneNumber);
         }
         if (!empty($frontendUserData['fax'])) {
             $phoneNumber = new PhoneNumber();
+            $phoneNumber->setPid($pid);
             $phoneNumber->setPhoneNumber((string)($frontendUserData['fax']));
             $phoneNumber->setType('fax');
             $contract->getPhoneNumbers()->attach($phoneNumber);

--- a/Classes/Provider/FrontendUserProvider.php
+++ b/Classes/Provider/FrontendUserProvider.php
@@ -26,7 +26,7 @@ final class FrontendUserProvider
     /**
      * @return array<int, array<string, mixed>>
      */
-    public function getUsersWithoutProfile(int $storagePid): array
+    public function getUsersWithoutProfile(): array
     {
         $queryBuilder = $this->connectionPool->getQueryBuilderForTable('fe_users');
         return $queryBuilder
@@ -44,8 +44,8 @@ final class FrontendUserProvider
             ->where(
                 $queryBuilder->expr()->isNull('tx_academicpersons_feuser_mm.uid_local'),
                 $queryBuilder->expr()->eq(
-                    'fe_users.pid',
-                    $queryBuilder->createNamedParameter($storagePid, Connection::PARAM_INT)
+                    'fe_users.tx_extbase_type',
+                    $queryBuilder->createNamedParameter('Tx_Academicpersonsedit_Domain_Model_FrontendUser', Connection::PARAM_STR)
                 )
             )
             ->groupBy('fe_users.uid')


### PR DESCRIPTION
**Changes:**

- Fetch users without profile by `tx_extbase_type` "Tx_Academicpersonsedit_Domain_Model_FrontendUser" instead by `UID` to avoid duplicate settings for PIDs in the scheduler commands and reduce the amount of needed scheduler commands to one no matter how many users groups are configured for the LDAP sync.
- Set the PIDs of all childs of a profile accordingly to the profile's PID to avoid errors with child records on regular pages.