### PR TITLE
Change handling of translations

### DIFF
--- a/Classes/Controller/ProfileController.php
+++ b/Classes/Controller/ProfileController.php
@@ -92,6 +92,7 @@ final class ProfileController extends ActionController
     {
         $profileUids = $this->context->getPropertyFromAspect('frontend.profile', 'allProfileUids', []);
 
+        // TODO: Don't return empty response if no profiles are assigned to user
         if (empty($profileUids)) {
             return $this->htmlResponse();
         }
@@ -135,6 +136,8 @@ final class ProfileController extends ActionController
         }
 
         $profileUids = $this->context->getPropertyFromAspect('frontend.profile', 'allProfileUids', []);
+
+        // TODO: To die() is no good way out here, talk to your trusted TYPO3 developer first
         if ($profile === null || !in_array($profile->getUid(), $profileUids)) {
             GeneralUtility::makeInstance(ErrorController::class)->accessDeniedAction(
                 $this->request,

--- a/Classes/Domain/Model/Profile.php
+++ b/Classes/Domain/Model/Profile.php
@@ -175,4 +175,9 @@ class Profile extends \Fgtclb\AcademicPersons\Domain\Model\Profile
     {
         return $this->_languageUid;
     }
+
+    public function getIsTranslation(): bool
+    {
+        return $this->_localizedUid !== $this->uid;
+    }
 }

--- a/Classes/Domain/Repository/ProfileRepository.php
+++ b/Classes/Domain/Repository/ProfileRepository.php
@@ -28,6 +28,7 @@ class ProfileRepository extends Repository
     public function findByUids(array $uids): QueryResultInterface
     {
         $query = $this->createQuery();
+        $query->getQuerySettings()->setRespectStoragePage(false);
 
         return $query
             ->matching(

--- a/Configuration/TCA/Overrides/fe_users.php
+++ b/Configuration/TCA/Overrides/fe_users.php
@@ -31,6 +31,7 @@ ExtensionManagementUtility::addTCAcolumns(
                 'type' => 'group',
                 'allowed' => 'tx_academicpersons_domain_model_profile',
                 'foreign_table' => 'tx_academicpersons_domain_model_profile',
+                'foreign_table_where' => 'AND tx_academicpersons_domain_model_profile.sys_language_uid IN (-1, 0)',
                 'MM' => 'tx_academicpersons_feuser_mm',
                 'MM_opposite_field' => 'frontend_users',
                 'size' => 5,

--- a/Configuration/TCA/Overrides/tt_content_plugins.php
+++ b/Configuration/TCA/Overrides/tt_content_plugins.php
@@ -16,11 +16,19 @@ ExtensionUtility::registerPlugin(
     'ProfileSwitcher',
     'LLL:EXT:academic_persons_edit/Resources/Private/Language/locallang_be.xlf:plugin.profile_switcher.label'
 );
-$GLOBALS['TCA']['tt_content']['types']['list']['subtypes_excludelist']['academicpersonsedit_profileswitcher'] = 'recursive,select_key';
+$GLOBALS['TCA']['tt_content']['types']['list']['subtypes_excludelist']['academicpersonsedit_profileswitcher'] = implode(',', [
+    'pages',
+    'recursive',
+    'select_key',
+]);
 
 ExtensionUtility::registerPlugin(
     'AcademicPersonsEdit',
     'ProfileEditing',
     'LLL:EXT:academic_persons_edit/Resources/Private/Language/locallang_be.xlf:plugin.profile_editing.label'
 );
-$GLOBALS['TCA']['tt_content']['types']['list']['subtypes_excludelist']['academicpersonsedit_profileediting'] = 'recursive,select_key';
+$GLOBALS['TCA']['tt_content']['types']['list']['subtypes_excludelist']['academicpersonsedit_profileediting'] = implode(',', [
+    'pages',
+    'recursive',
+    'select_key',
+]);


### PR DESCRIPTION
## Changes

- Ignore storage PID for profile switcher select options (they are already kown, because they are assigned to the frontend user)
- Assign only profiles in default language to fe_users (this follows the default handling of translated records in Extbase)
- Remove storage PID settings from plugins (storage PID selection is not needed as the records can be found via the frontend user - see above)
- Add method to check if selected profile is a translated version (we need this information in frontend to disable fields for editing, which should be not translated)
- Add some TODO reminder to make the error handling of the controller more user friendly