### PR TITLE
[TASK] Maintain main branch for 1.x.x

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,21 +3,25 @@ on:
   push:
     tags:
       - '*'
+
 jobs:
   publish:
-    name: Publish new version to TER
+    name: Ensure GitHub Release with extension TER artifact and publishing to TER
     if: startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     env:
       TYPO3_EXTENSION_KEY: ${{ secrets.TYPO3_EXTENSION_KEY }}
       TYPO3_API_TOKEN: ${{ secrets.TYPO3_API_TOKEN }}
+    permissions:
+      contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Check tag
+      - name: Verify tag
         run: |
           if ! [[ ${{ github.ref }} =~ ^refs/tags/[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}$ ]]; then
+            echo "ERR: Invalid publish version tag: ${{ github.ref }}"
             exit 1
           fi
 
@@ -28,13 +32,19 @@ jobs:
       - name: Get comment
         id: get-comment
         run: |
-          readonly local comment=$(git tag -n10 -l ${{ env.version }} | sed "s/^[0-9.]*[ ]*//g")
-
-          if [[ -z "${comment// }" ]]; then
-            echo "comment=Released version ${{ env.version }} of ${{ env.TYPO3_EXTENSION_KEY }}" >> $GITHUB_ENV
-          else
-            echo "comment=$comment" >> $GITHUB_ENV
+          readonly local releaseCommentPrependBody="$( git tag -l ${{ env.version }} --format '%(contents)' )"
+          if (( $(grep -c . <<<"${releaseCommentPrependBody// }") > 1 )); then
+            {
+              echo 'releaseCommentPrependBody<<EOF'
+              echo "$releaseCommentPrependBody"
+              echo EOF
+            } >> "$GITHUB_ENV"
           fi
+          {
+            echo 'terReleaseNotes<<EOF'
+            echo "https://github.com/fgtclb/academic-persons/releases/tag/${{ env.version }}"
+            echo EOF
+          } >> "$GITHUB_ENV"
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -46,5 +56,32 @@ jobs:
       - name: Install tailor
         run: composer global require typo3/tailor --prefer-dist --no-progress --no-suggest
 
+      # Note that step will fail when `env.version` does not match the `ext_emconf.php` version.
+      - name: Create local TER package upload artifact
+        run: |
+          php ~/.composer/vendor/bin/tailor create-artefact ${{ env.version }}
+
+      # Note that when release already exists for tag, only files will be uploaded and lets this acting as a
+      # fallback to ensure that a real GitHub release is created for the tag along with extension artifacts.
+      - name: Create release and upload artifacts in the same step
+        uses: softprops/action-gh-release@v2
+        if: ${{startsWith(github.ref, 'refs/tags/') }}
+        with:
+          name: "[RELEASE] ${{ env.version }}"
+          body: "${{ env.releaseCommentPrependBody }}"
+          generate_release_notes: true
+          files: |
+            tailor-version-artefact/${{ env.TYPO3_EXTENSION_KEY }}_${{ env.version }}.zip
+            LICENSE
+          fail_on_unmatched_files: true
+
+      # @todo Currently an issue exists with the TYPO3 Extension Repository (TER) tailor based uploads, which seems to
+      #       be WAF related and the T3O TER Team working on. Allow this step to fail (continue on error) for now until
+      #       issues has been sorted out.
+      #       https://github.com/TYPO3/tailor/issues/82
       - name: Publish to TER
-        run: php ~/.composer/vendor/bin/tailor ter:publish --comment "${{ env.comment }}" ${{ env.version }}
+        # @todo Remove `continue-on-error` after upload with tailor has been fixed.
+        continue-on-error: true
+        run: |
+          php ~/.composer/vendor/bin/tailor ter:publish --comment "${{ env.terReleaseNotes }}" ${{ env.version }} \
+            --artefact=tailor-version-artefact/${{ env.TYPO3_EXTENSION_KEY }}_${{ env.version }}.zip

--- a/.github/workflows/testcore11.yml
+++ b/.github/workflows/testcore11.yml
@@ -6,14 +6,14 @@ on:
 jobs:
   code-quality:
     name: "code quality with core v11"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         php-version: [ '8.0']
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: "Link docker compose"
         run: |
@@ -48,7 +48,7 @@ jobs:
 
   testsuite:
     name: all tests with core v11
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     needs: code-quality
     strategy:
       fail-fast: false
@@ -56,7 +56,7 @@ jobs:
         php-version: [ '8.0', '8.1', '8.2' ]
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: "Link docker compose"
         run: |

--- a/.github/workflows/testcore11.yml
+++ b/.github/workflows/testcore11.yml
@@ -68,8 +68,8 @@ jobs:
       - name: "Prepare dependencies for TYPO3 v11"
         run: "Build/Scripts/runTests.sh -t 11 -p ${{ matrix.php-version }} -s composerUpdate"
 
-#      - name: "Unit"
-#        run: "Build/Scripts/runTests.sh -t 11 -p ${{ matrix.php-version }} -s unit"
+      - name: "Unit"
+        run: "Build/Scripts/runTests.sh -t 11 -p ${{ matrix.php-version }} -s unit"
 
 #      - name: "Functional SQLite"
 #        run: "Build/Scripts/runTests.sh -t 11 -p ${{ matrix.php-version }} -s functional -d sqlite"

--- a/.github/workflows/testcore11.yml
+++ b/.github/workflows/testcore11.yml
@@ -71,23 +71,23 @@ jobs:
 #      - name: "Unit"
 #        run: "Build/Scripts/runTests.sh -t 11 -p ${{ matrix.php-version }} -s unit"
 
-      - name: "Functional SQLite"
-        run: "Build/Scripts/runTests.sh -t 11 -p ${{ matrix.php-version }} -s functional -d sqlite"
-
-      - name: "Functional MariaDB 10.5 mysqli"
-        run: "Build/Scripts/runTests.sh -t 11 -p ${{ matrix.php-version }} -s functional -d mariadb -a mysqli"
-
-      - name: "Functional MariaDB 10.5 pdo_mysql"
-        run: "Build/Scripts/runTests.sh -t 11 -p ${{ matrix.php-version }} -s functional -d mariadb -a pdo_mysql"
-
-      - name: "Functional MySQL 8.0 mysqli"
-        run: "Build/Scripts/runTests.sh -t 11 -p ${{ matrix.php-version }} -s functional -d mariadb -a mysqli"
-
-      - name: "Functional MySQL 8.0 pdo_mysql"
-        run: "Build/Scripts/runTests.sh -t 11 -p ${{ matrix.php-version }} -s functional -d mariadb -a pdo_mysql"
-
-      - name: "Functional PostgresSQL 10"
-        # v11 postgres functional disabled with PHP 8.2 since https://github.com/doctrine/dbal/commit/73eec6d882b99e1e2d2d937accca89c1bd91b2d7
-        # is not fixed in doctrine core v11 doctrine 2.13.9
-        if: ${{ matrix.php <= '8.1' }}
-        run: "Build/Scripts/runTests.sh -t 11 -p ${{ matrix.php-version }} -s functional -d postgres"
+#      - name: "Functional SQLite"
+#        run: "Build/Scripts/runTests.sh -t 11 -p ${{ matrix.php-version }} -s functional -d sqlite"
+#
+#      - name: "Functional MariaDB 10.5 mysqli"
+#        run: "Build/Scripts/runTests.sh -t 11 -p ${{ matrix.php-version }} -s functional -d mariadb -a mysqli"
+#
+#      - name: "Functional MariaDB 10.5 pdo_mysql"
+#        run: "Build/Scripts/runTests.sh -t 11 -p ${{ matrix.php-version }} -s functional -d mariadb -a pdo_mysql"
+#
+#      - name: "Functional MySQL 8.0 mysqli"
+#        run: "Build/Scripts/runTests.sh -t 11 -p ${{ matrix.php-version }} -s functional -d mariadb -a mysqli"
+#
+#      - name: "Functional MySQL 8.0 pdo_mysql"
+#        run: "Build/Scripts/runTests.sh -t 11 -p ${{ matrix.php-version }} -s functional -d mariadb -a pdo_mysql"
+#
+#      - name: "Functional PostgresSQL 10"
+#        # v11 postgres functional disabled with PHP 8.2 since https://github.com/doctrine/dbal/commit/73eec6d882b99e1e2d2d937accca89c1bd91b2d7
+#        # is not fixed in doctrine core v11 doctrine 2.13.9
+#        if: ${{ matrix.php <= '8.1' }}
+#        run: "Build/Scripts/runTests.sh -t 11 -p ${{ matrix.php-version }} -s functional -d postgres"

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@
 
 /.cache/
 /Build/testing-docker/.env
+
+/tailor-version-artefact/
+/tailor-version-upload/

--- a/Build/testing-docker/docker-compose.yml
+++ b/Build/testing-docker/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   # This is the service name used when running ddev commands accepting the
   # --service flag.

--- a/Classes/Property/TypeConverter/ProfileImageUploadConverter.php
+++ b/Classes/Property/TypeConverter/ProfileImageUploadConverter.php
@@ -160,26 +160,25 @@ final class ProfileImageUploadConverter extends AbstractTypeConverter implements
      */
     private function validateUploadedFile(array $uploadedFileInformation, string $maxFileSize, string $allowedMimeTypes): void
     {
-        $typoScriptFrontendController = $this->getTypo3Request()->getAttribute('frontend.controller');
+        $typoScriptFrontendController = $this->getTypo3Request()->getAttribute('frontend.controller') ?? $GLOBALS['TSFE'] ?? null;
         $maxFileSizeInBytes = GeneralUtility::getBytesFromSizeMeasurement($maxFileSize);
         $allowedMimeTypesArray = GeneralUtility::trimExplode(',', $allowedMimeTypes);
 
         if ($uploadedFileInformation['size'] > $maxFileSizeInBytes) {
-            $message = $typoScriptFrontendController->sL('EXT:form/Resources/Private/Language/locallang.xlf:upload.error.150530345');
             throw new TypeConverterException(
-                $typoScriptFrontendController->sL(
+                $typoScriptFrontendController?->sL(
                     'LLL:EXT:form/Resources/Private/Language/locallang.xlf:upload.error.150530345'
-                ),
+                ) ?? 'Upload error',
                 1690538138
             );
         }
         if (!in_array($uploadedFileInformation['type'], $allowedMimeTypesArray, true)) {
             throw new TypeConverterException(
-                $typoScriptFrontendController->sL(
+                $typoScriptFrontendController?->sL(
                     'LLL:EXT:form/Resources/Private/Language/locallang.xlf:validation.error.1471708998',
                     null,
                     $uploadedFileInformation['type'],
-                ),
+                ) ?? 'Validation error',
                 1695047315
             );
         }

--- a/README.md
+++ b/README.md
@@ -10,3 +10,61 @@ Profiles get connected with a frontend user and the frontend user is allow to ed
 ```shell
 composer require fgtclb/academic-persons-edit
 ```
+
+## Create a release (maintainers only)
+
+Prerequisites:
+
+* git binary
+* ssh key allowed to push new branches to the repository
+* GitHub command line tool `gh` installed and configured with user having permission to create pull requests.
+
+**Prepare release locally**
+
+> Set `RELEASE_BRANCH` to branch release should happen, for example: 'main'.
+> Set `RELEASE_VERSION` to release version working on, for example: '1.1.0'.
+
+```shell
+echo '>> Prepare release pull-request' ; \
+  RELEASE_BRANCH='main' ; \
+  RELEASE_VERSION='1.1.0' ; \
+  git checkout main && \
+  git fetch --all && \
+  git pull --rebase && \
+  git checkout ${RELEASE_BRANCH} && \
+  git pull --rebase && \
+  git checkout -b prepare-release-${RELEASE_VERSION} && \
+  composer require --dev "typo3/tailor" && \
+  ./.Build/bin/tailor set-version ${RELEASE_VERSION} && \
+  composer remove --dev "typo3/tailor" && \
+  git add . && \
+  git commit -m "[RELEASE] ${RELEASE_VERSION}" && \
+  git push --set-upstream origin prepare-release-${RELEASE_VERSION} && \
+  gh pr create --fill-verbose --base ${RELEASE_BRANCH} --title "[RELEASE] ${RELEASE_VERSION}" && \
+  git checkout main && \
+  git branch -D prepare-release-${RELEASE_VERSION}
+```
+
+Check pull-request and the pipeline run.
+
+**Merge approved pull-request and push version tag**
+
+> Set `RELEASE_PR_NUMBER` with the pull-request number of the preparation pull-request.
+> Set `RELEASE_BRANCH` to branch release should happen, for example: 'main' (same as in previous step).
+> Set `RELEASE_VERSION` to release version working on, for example: `1.1.0` (same as in previous step).
+
+```shell
+RELEASE_BRANCH='main' ; \
+RELEASE_VERSION='1.1.0' ; \
+RELEASE_PR_NUMBER='123' ; \
+  git checkout main && \
+  git fetch --all && \
+  git pull --rebase && \
+  gh pr checkout ${RELEASE_PR_NUMBER} && \
+  gh pr merge -rd ${RELEASE_PR_NUMBER} && \
+  git tag ${RELEASE_VERSION} && \
+  git push --tags
+```
+
+This triggers the `on push tags` workflow (`publish.yml`) which creates the upload package,
+creates the GitHub release and also uploads the release to the TYPO3 Extension Repository.

--- a/composer.json
+++ b/composer.json
@@ -25,22 +25,22 @@
         }
     },
     "require": {
-        "php": "^8.0",
-        "typo3/cms-core": "^11.5",
-        "fgtclb/academic-persons": "dev-main"
+        "php": "^8.0 || ^8.1 || ^8.2 || ^8.3",
+        "fgtclb/academic-persons": "^1.0 || 1.*.*@dev",
+        "typo3/cms-core": "^11.5"
     },
     "require-dev": {
-        "typo3/minimal": "v11.5.0",
-        "typo3/cms-composer-installers": "v4.0.0-RC1",
-        "kaystrobach/migrations": "0.11.0",
-        "helhum/typo3-console": "^7.1 || ^8.0",
-        "saschaegerer/phpstan-typo3": "^1.8",
-        "friendsofphp/php-cs-fixer": "^3.14",
-        "typo3/cms-felogin": "^11.5",
         "andreaswolf/typo3-uuid": "^0.3.0",
-        "typo3/testing-framework": "^7.0",
         "bk2k/bootstrap-package": "^14.0",
-        "cweagans/composer-patches": "^1.7"
+        "cweagans/composer-patches": "^1.7",
+        "friendsofphp/php-cs-fixer": "^3.14",
+        "helhum/typo3-console": "^7.1.6 || ^8.2",
+        "kaystrobach/migrations": "0.11.0",
+        "saschaegerer/phpstan-typo3": "^1.8",
+        "typo3/cms-composer-installers": "v4.0.0-RC1",
+        "typo3/cms-felogin": "^11.5",
+        "typo3/minimal": "v11.5.0",
+        "typo3/testing-framework": "^7.0"
     },
     "autoload": {
         "psr-4": {
@@ -56,7 +56,8 @@
     "config": {
         "vendor-dir": ".Build/vendor",
         "bin-dir": ".Build/bin",
-        "allow-plugins": true
+        "allow-plugins": true,
+        "sort-packages": true
     },
     "scripts": {
         "post-autoload-dump": [
@@ -73,6 +74,9 @@
             "kaystrobach/migrations": {
                 "Load migrations from autoload-dev": "patches/migrations/autoload.patch"
             }
+        },
+        "banch-alias": {
+            "dev-main": "1.x.x-dev"
         }
     }
 }

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -13,7 +13,9 @@ $EM_CONF[$_EXTKEY] = [
     'constraints' => [
         'depends' => [
             'typo3' => '11.5.0-11.5.99',
-            'academic_persons' => '0.2.0 - 0.2.99',
+            // @todo Change this to '1.0.0-1.99.99' after academic_persons has been released.
+            //       TYPO3 does not support dev-constraints like `2.*.*` as composer.
+            'academic_persons' => '0.2.0 - 1.99.99',
         ],
         'conflicts' => [
         ],


### PR DESCRIPTION
- **[TASK] Maintain `composer.json` and `ext_emconf.php`**
  * Set `sort-packages: true` option in `composer.json`.
  * Set banch-alias for main to `1.x.x-dev`.
  * Minor adjustment of dependencies and development
    dependencies.
  * Align `ext_emconf.php` dependencies with defined
    dependencies in `composer.json`.
  
  Used command(s):
  
  ```shell
  composer config sort-packages true \
  && composer config extra.banch-alias.dev-main "1.x.x-dev" \
  && composer require --no-update \
    'php':'^8.0 || ^8.1 || ^8.2 || ^8.3' \
    'typo3/cms-core':'^11.5' \
    'fgtclb/academic-persons':'^1.0 || 1.*.*@dev' \
  && composer require --dev --no-update \
    'helhum/typo3-console':'^7.1.6 || ^8.2' \
    'typo3/cms-felogin':'^11.5'
  ```
  

- **[TASK] Streamline GitHub action workflow publish**

  The current `publish` github action workflow is
  streamlined to work in a more smoother way and
  also respect current broken automatic releasing
  with tailor to the TYPO3 Extension Registry.
  
  This includes:
  
  * Using a simpler way to get the tag message for
    requested version based on the tag and avoid
    sed issues. Makes the part a little bit more
    obvious.
  * Using tailor to create an upload artifact in
    a first step.
  * Create an github release from the tag using
    the extracted tag message as prepand message
    along with attaching the tailor upload pack
    artifact to the release. If release already
    exists, only the artifact is attached.
  * Try uploading created upload artifact to the
    TER, but do not fail in case it does not work
    yet. **Be aware** that this must checked manually,
    but attached artifact can simply be used to
    upload it manually to TER mitigating the need
    to build it locally again for the tag.
  * Enhance the `README.md` to document required
    release workflow for maintainers.
  
- **[TASK] Mitigate missing TypoScriptFrontendController as request attribute**

  It may be possible that the `TypoScriptFrontendController` is not
  set as `frontend.controller` request attribute. Use proper fallback
  handling in these cases:

  * Fallback to `$GLOBALS['TSFE']`.
  * Ensure calls to TSFE methods to deal with the fact that the
    TSFE may not be available even with the global fallback.

- **[TASK] Remove obsolete `version` from docker-compose**

  docker-compose deprecated the `version` option 
  in `docker-compose.yml` files. To avoid notices
  the option is now removed.

- **[TASK] Streamline v11 testing workflow**

  This change streamlines the v11 GitHub action
  workflow.

  * Use `checkout@v4` in jobs.
  * Use `ubuntu-latest` as image.

- **[TASK] Disable functional tests in GitHub workflow**

  This extension does not contain any functional
  tests. Disable them in the GitHub workflow.

- **[TASK] Enable unit test in GitHub action workflow**

  This extension has unit tests, enable them as CI run.
