### PR TITLE
[BUGFIX] Fix typo in composer branch alias key

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -75,7 +75,7 @@
                 "Load migrations from autoload-dev": "patches/migrations/autoload.patch"
             }
         },
-        "banch-alias": {
+        "branch-alias": {
             "dev-main": "1.x.x-dev"
         }
     }


### PR DESCRIPTION
Used command(s):

```shell
composer config \
  extra.branch-alias.dev-main "1.x.x-dev"
&& composer config --unset extra.banch-alias
```
