### PR TITLE
[TASK] Enable TYPO3 v11 and v12 support for 1.x.x

### DIFF
--- a/.github/workflows/testcore11.yml
+++ b/.github/workflows/testcore11.yml
@@ -53,7 +53,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: [ '8.0', '8.1', '8.2' ]
+        php-version: [ '8.0', '8.1', '8.2', '8.3' ]
     steps:
       - name: "Checkout"
         uses: actions/checkout@v4

--- a/.github/workflows/testcore12.yml
+++ b/.github/workflows/testcore12.yml
@@ -1,0 +1,93 @@
+name: tests core 12
+
+on:
+  pull_request:
+
+jobs:
+  code-quality:
+    name: "code quality with core v12"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: [ '8.1' ]
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v4
+
+      - name: "Link docker compose"
+        run: |
+          echo "#!/usr/bin/env bash" > /usr/local/bin/docker-compose
+          echo "" >> /usr/local/bin/docker-compose
+          echo "docker compose \"\$@\"" >> /usr/local/bin/docker-compose
+          chmod a+x /usr/local/bin/docker-compose
+
+      - name: "Prepare dependencies for TYPO3 v12"
+        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s composerUpdate"
+
+      - name: "Run TypoScript lint"
+        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s lintTypoScript"
+
+      - name: "Run PHP lint"
+        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s lintPhp"
+
+      - name: "Validate CGL"
+        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s cgl"
+
+      - name: "Ensure UTF-8 files do not contain BOM"
+        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s checkBom"
+
+      - name: "Test .rst files for integrity"
+        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s checkRst"
+
+      - name: "Find duplicate exception codes"
+        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s checkExceptionCodes"
+
+      - name: "Run PHPStan"
+        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s phpstan"
+
+  testsuite:
+    name: all tests with core v12
+    runs-on: ubuntu-latest
+    needs: code-quality
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: [ '8.1', '8.2', '8.3' ]
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v4
+
+      - name: "Link docker compose"
+        run: |
+          echo "#!/usr/bin/env bash" > /usr/local/bin/docker-compose
+          echo "" >> /usr/local/bin/docker-compose
+          echo "docker compose \"\$@\"" >> /usr/local/bin/docker-compose
+          chmod a+x /usr/local/bin/docker-compose
+
+      - name: "Prepare dependencies for TYPO3 v12"
+        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s composerUpdate"
+
+      - name: "Unit"
+        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s unit"
+
+#      - name: "Functional SQLite"
+#        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s functional -d sqlite"
+#
+#      - name: "Functional MariaDB 10.5 mysqli"
+#        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s functional -d mariadb -a mysqli"
+#
+#      - name: "Functional MariaDB 10.5 pdo_mysql"
+#        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s functional -d mariadb -a pdo_mysql"
+#
+#      - name: "Functional MySQL 8.0 mysqli"
+#        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s functional -d mariadb -a mysqli"
+#
+#      - name: "Functional MySQL 8.0 pdo_mysql"
+#        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s functional -d mariadb -a pdo_mysql"
+#
+#      - name: "Functional PostgresSQL 10"
+#        # v12 postgres functional disabled with PHP 8.2 since https://github.com/doctrine/dbal/commit/73eec6d882b99e1e2d2d937accca89c1bd91b2d7
+#        # is not fixed in doctrine core v12 doctrine 2.13.9
+#        if: ${{ matrix.php <= '8.1' }}
+#        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s functional -d postgres"

--- a/Build/Scripts/composer-for-core-version.sh
+++ b/Build/Scripts/composer-for-core-version.sh
@@ -23,7 +23,7 @@ composer_update() {
 update_v12() {
     echo -e "💪 Enforce TYPO3 v12"
     composer require --no-update \
-        "typo3/cms-core":"^12.4"
+        "typo3/minimal":"^12.4"
 
     echo -e "💪 Enforce PHPUnit ^10.1"
     composer req --dev --no-update \
@@ -33,7 +33,7 @@ update_v12() {
 update_v11() {
     echo -e "💪 Enforce TYPO3 v11"
     composer require --no-update \
-        "typo3/cms-core":"^11.5"
+        "typo3/minimal":"^11.5"
 
     echo -e "💪 Enforce PHPUnit ^9.6.8"
     composer req --dev --no-update \

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -105,12 +105,12 @@ Options:
             - mysql: use mysql
             - postgres: use postgres
 
-    -p <7.4|8.0|8.1|8.2>
+    -p <8.0|8.1|8.2|8.3>
         Specifies the PHP minor version to be used
-            - 7.4 (default): use PHP 7.4
-            - 8.0: use PHP 8.0
+            - 8.0: use PHP 8.0 (default)
             - 8.1: use PHP 8.1
             - 8.2: use PHP 8.2
+            - 8.3: use PHP 8.3
 
     -t <11|12>
         Only with -s composerUpdate
@@ -191,7 +191,7 @@ else
 fi
 TEST_SUITE=""
 DBMS="sqlite"
-PHP_VERSION="7.4"
+PHP_VERSION="8.0"
 TYPO3_VERSION="11"
 PHP_XDEBUG_ON=0
 EXTRA_TEST_OPTIONS=""
@@ -219,7 +219,7 @@ while getopts ":s:a:d:p:t:e:xnhuv" OPT; do
             ;;
         p)
             PHP_VERSION=${OPTARG}
-            if ! [[ ${PHP_VERSION} =~ ^(7.4|8.0|8.1|8.2)$ ]]; then
+            if ! [[ ${PHP_VERSION} =~ ^(8.0|8.1|8.2|8.3)$ ]]; then
                 INVALID_OPTIONS+=("p ${OPTARG}")
             fi
             ;;

--- a/Build/phpstan/Core11/phpstan-baseline.neon
+++ b/Build/phpstan/Core11/phpstan-baseline.neon
@@ -1,6 +1,16 @@
 parameters:
 	ignoreErrors:
 		-
+			message: "#^Call to method enableUuidForTable\\(\\) on an unknown class AndreasWolf\\\\Uuid\\\\Service\\\\TableConfigurationService\\.$#"
+			count: 1
+			path: ../../../Configuration/TCA/Overrides/uuids.php
+
+		-
+			message: "#^Class AndreasWolf\\\\Uuid\\\\Service\\\\TableConfigurationService not found\\.$#"
+			count: 1
+			path: ../../../Configuration/TCA/Overrides/uuids.php
+
+		-
 			message: "#^Variable \\$_EXTKEY might not be defined\\.$#"
 			count: 1
 			path: ../../../ext_emconf.php

--- a/Build/phpstan/Core12/phpstan-baseline.neon
+++ b/Build/phpstan/Core12/phpstan-baseline.neon
@@ -1,6 +1,16 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Variable \\$_EXTKEY might not be defined\\.$#"
+			message: "#^Method Fgtclb\\\\AcademicPersonsEdit\\\\Domain\\\\Model\\\\Profile\\:\\:getLanguageUid\\(\\) should return int but returns int\\<\\-1, max\\>\\|null\\.$#"
 			count: 1
-			path: ../../../ext_emconf.php
+			path: ../../../Classes/Domain/Model/Profile.php
+
+		-
+			message: "#^Parameter \\#1 \\.\\.\\.\\$constraints of method TYPO3\\\\CMS\\\\Extbase\\\\Persistence\\\\QueryInterface\\<Fgtclb\\\\AcademicPersonsEdit\\\\Domain\\\\Model\\\\Address\\>\\:\\:logicalAnd\\(\\) expects TYPO3\\\\CMS\\\\Extbase\\\\Persistence\\\\Generic\\\\Qom\\\\ConstraintInterface, array\\<int, TYPO3\\\\CMS\\\\Extbase\\\\Persistence\\\\Generic\\\\Qom\\\\ComparisonInterface\\> given\\.$#"
+			count: 1
+			path: ../../../Classes/Domain/Repository/AddressRepository.php
+
+		-
+			message: "#^Parameter \\#1 \\$pid of method TYPO3\\\\CMS\\\\Extbase\\\\DomainObject\\\\AbstractDomainObject\\:\\:setPid\\(\\) expects int\\<0, max\\>, int given\\.$#"
+			count: 6
+			path: ../../../Classes/Profile/ProfileFactory.php

--- a/composer.json
+++ b/composer.json
@@ -14,30 +14,18 @@
         "issues": "https://github.com/fgtclb/academic-persons-edit/issues",
         "source": "https://github.com/fgtclb/academic-persons-edit"
     },
-    "repositories": {
-        "academic-persons": {
-            "type": "git",
-            "url": "https://github.com/fgtclb/academic-persons.git"
-        },
-        "typo3-ext-migrations": {
-            "type": "git",
-            "url": "https://github.com/andreaswolf/typo3-ext-migrations.git"
-        }
-    },
     "require": {
         "php": "^8.0 || ^8.1 || ^8.2 || ^8.3",
         "fgtclb/academic-persons": "^1.0 || 1.*.*@dev",
-        "typo3/cms-core": "^11.5"
+        "typo3/cms-core": "^11.5 || ^12.4"
     },
     "require-dev": {
-        "andreaswolf/typo3-uuid": "^0.3.0",
         "bk2k/bootstrap-package": "^14.0",
         "friendsofphp/php-cs-fixer": "^3.14",
         "helhum/typo3-console": "^7.1.6 || ^8.2",
         "saschaegerer/phpstan-typo3": "^1.8",
-        "typo3/cms-composer-installers": "v4.0.0-RC1",
-        "typo3/cms-felogin": "^11.5",
-        "typo3/minimal": "v11.5.0",
+        "typo3/cms-composer-installers": "v4.0.0-RC2 || ^5",
+        "typo3/cms-felogin": "^11.5 || ^12.4",
         "typo3/testing-framework": "^7.0"
     },
     "autoload": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -12,10 +12,8 @@ $EM_CONF[$_EXTKEY] = [
     'clearCacheOnLoad' => true,
     'constraints' => [
         'depends' => [
-            'typo3' => '11.5.0-11.5.99',
-            // @todo Change this to '1.0.0-1.99.99' after academic_persons has been released.
-            //       TYPO3 does not support dev-constraints like `2.*.*` as composer.
-            'academic_persons' => '0.2.0 - 1.99.99',
+            'typo3' => '11.5.0-12.4.99',
+            'academic_persons' => '1.1.0-1.99.99',
         ],
         'conflicts' => [
         ],


### PR DESCRIPTION
Used command(s):

```shell
composer remove --dev --no-update \
  'andreaswolf/typo3-uuid' \
  'typo3/minimal' \
&& composer config --unset repositories \
&& composer require --no-update \
  'typo3/cms-core':'^11.5 || ^12.4' \
&& composer require --dev --no-update \
  'typo3/cms-composer-installers':'v4.0.0-RC2 || ^5'
```
